### PR TITLE
fix null pointer in health call when metrics.lastCommit or lastFetch …

### DIFF
--- a/src/views/portfolio/projects/ComponentHealth.vue
+++ b/src/views/portfolio/projects/ComponentHealth.vue
@@ -190,12 +190,14 @@ export default {
   },
   computed: {
     formattedLastCommit() {
+      if (!this.metrics || !this.metrics.lastCommit) return 'N/A';
       const date = new Date(this.metrics.lastCommit);
       return isNaN(date.getTime())
         ? 'N/A'
         : common.formatTimestamp(date.getTime(), true);
     },
     formattedLastFetch() {
+      if (!this.metrics || !this.metrics.lastFetch) return 'N/A';
       const date = new Date(this.metrics.lastFetch);
       return isNaN(date.getTime())
         ? 'N/A'


### PR DESCRIPTION
 when metrics.lastCommit or lastFetch is null, then the health checks for scorecard are not displayed on the page:
 

<img width="1262" height="608" alt="image" src="https://github.com/user-attachments/assets/a36b0a20-32da-4c39-a6e0-60e686a4e690" />

 

### Description
A validattion for non-null values was enough so that the page can render the scorecard findings.
<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x ] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly
